### PR TITLE
Without that space, I find things like TCPspecification, workboth, ...

### DIFF
--- a/rfctxt2kindlehtml.py
+++ b/rfctxt2kindlehtml.py
@@ -145,7 +145,7 @@ def main():
                 in_p = False
             continue
         
-        buffer.append(line.replace("\n", ''))
+        buffer.append(line.replace("\n", ' '))
 
     buffer.append('</body>')
     buffer = ''.join(buffer)


### PR DESCRIPTION
This replaces \n for a space. Without this I get two words without a space between.
